### PR TITLE
feat: Per-model maxTokens config for thinking models

### DIFF
--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -33,6 +33,7 @@ export const MODELS: SynthesisModel[] = [
     openRouterId: 'google/gemini-2.5-pro',
     description: 'Strong cross-domain connections',
     costTier: 'premium',
+    maxTokens: 8000,
   },
   {
     id: 'llama-70b',
@@ -54,6 +55,7 @@ export const MODELS: SynthesisModel[] = [
     openRouterId: 'x-ai/grok-3-mini',
     description: 'Contrarian tendency valuable for debate seeding',
     costTier: 'standard',
+    maxTokens: 8000,
   },
 ];
 

--- a/src/pipeline/synthesis.ts
+++ b/src/pipeline/synthesis.ts
@@ -79,6 +79,7 @@ export async function generateSynthesisMatrix(
         const result = await callOpenRouter({
           model: combo.model.openRouterId,
           prompt,
+          maxTokens: combo.model.maxTokens,
           logger: log,
           context: {
             framework: combo.framework.id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -243,6 +243,8 @@ export interface SynthesisModel {
   description: string;
   /** Cost tier for reference */
   costTier: 'budget' | 'standard' | 'premium';
+  /** Optional max tokens override for thinking models that need more headroom */
+  maxTokens?: number;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Add per-model `maxTokens` configuration so thinking models (Gemini 2.5 Pro, Grok 3 Mini) can request 8000 tokens instead of the default 1500. Fixes truncated ~300 char responses from thinking models that consume most of the token budget on internal reasoning.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/types.ts` | UPDATE | Add optional `maxTokens?: number` field to `SynthesisModel` interface |
| `src/config/models.ts` | UPDATE | Set `maxTokens: 8000` on gemini-pro and grok-mini |
| `src/pipeline/synthesis.ts` | UPDATE | Thread `combo.model.maxTokens` to `callOpenRouter()` options |

## Tests

No new tests — this is a config-level threading of an existing parameter with no new functions or logic branches. No test files exist in the codebase.

## Validation

- [x] Type check passes (`bun run typecheck`)
- [ ] Lint — skipped (no eslint.config.js in project)
- [ ] Tests — skipped (no test files in codebase)
- [ ] Build — N/A (Bun runtime, runs TypeScript directly)

## Implementation Notes

- No deviations from plan
- No issues encountered
- The OpenRouter client already accepts optional `maxTokens` with default 1500 — no changes needed there
- Only 2 of 6 models get `maxTokens` set; the other 4 use the existing default

---

**Workflow ID**: `39eb6ff7a58ffa01a8e20fdfb8e466b4`
