### PR TITLE
feat: add SQLite database module with migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ npm-debug.log*
 
 # Test coverage
 coverage/
+
+# Database (runtime artifact)
+data/
+
+# Archon tooling
+.archon/

--- a/src/db/connection.test.ts
+++ b/src/db/connection.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { getDatabase, closeDatabase } from './connection';
+
+describe('getDatabase', () => {
+  beforeEach(() => {
+    // Use an in-memory DB for tests by overriding DB_PATH
+    process.env.DB_PATH = ':memory:';
+    closeDatabase(); // reset singleton
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    delete process.env.DB_PATH;
+  });
+
+  test('returns a Database instance', () => {
+    const db = getDatabase();
+    expect(db).toBeInstanceOf(Database);
+  });
+
+  test('returns the same singleton on repeated calls', () => {
+    const db1 = getDatabase();
+    const db2 = getDatabase();
+    expect(db1).toBe(db2);
+  });
+
+  test('has WAL journal mode enabled', () => {
+    const db = getDatabase();
+    const row = db.query<{ journal_mode: string }, []>('PRAGMA journal_mode;').get();
+    expect(row?.journal_mode).toBe('wal');
+  });
+
+  test('has foreign key enforcement enabled', () => {
+    const db = getDatabase();
+    const row = db.query<{ foreign_keys: number }, []>('PRAGMA foreign_keys;').get();
+    expect(row?.foreign_keys).toBe(1);
+  });
+
+  test('is usable for queries', () => {
+    const db = getDatabase();
+    const row = db.query<{ val: number }, []>('SELECT 1 AS val;').get();
+    expect(row?.val).toBe(1);
+  });
+});
+
+describe('closeDatabase', () => {
+  beforeEach(() => {
+    process.env.DB_PATH = ':memory:';
+    closeDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    delete process.env.DB_PATH;
+  });
+
+  test('is a no-op when no connection is open', () => {
+    // Should not throw
+    expect(() => closeDatabase()).not.toThrow();
+  });
+
+  test('resets singleton so next call opens a fresh connection', () => {
+    const db1 = getDatabase();
+    closeDatabase();
+    const db2 = getDatabase();
+    expect(db2).not.toBe(db1);
+  });
+});

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,0 +1,48 @@
+/**
+ * ISEE v2 — Database Connection
+ *
+ * Provides a singleton SQLite connection using Bun's built-in SQLite driver.
+ * The database file path is configurable via the DB_PATH environment variable,
+ * defaulting to ./data/isee.db.
+ */
+
+import { Database } from 'bun:sqlite';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const DB_PATH = process.env.DB_PATH || './data/isee.db';
+
+let _db: Database | null = null;
+
+/**
+ * Returns the singleton SQLite database connection.
+ * Creates the database file and parent directory if they do not exist.
+ * WAL mode is enabled for better read concurrency during long pipeline runs.
+ */
+export function getDatabase(): Database {
+  if (_db) return _db;
+
+  // Ensure the parent directory exists
+  mkdirSync(dirname(DB_PATH), { recursive: true });
+
+  _db = new Database(DB_PATH, { create: true });
+
+  // Enable WAL mode for better concurrent read performance
+  _db.exec('PRAGMA journal_mode = WAL;');
+
+  // Enforce foreign key constraints
+  _db.exec('PRAGMA foreign_keys = ON;');
+
+  return _db;
+}
+
+/**
+ * Closes the database connection and resets the singleton.
+ * Intended for graceful shutdown and test teardown.
+ */
+export function closeDatabase(): void {
+  if (_db) {
+    _db.close();
+    _db = null;
+  }
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,24 @@
+/**
+ * ISEE v2 — Database Module
+ *
+ * Entry point for all database operations.
+ * Call `initDatabase()` once at server startup before handling any requests.
+ */
+
+export { getDatabase, closeDatabase } from './connection';
+export { runMigrations } from './migrations';
+export type { Migration } from './migrations';
+export { migrations } from './schema';
+
+import { getDatabase } from './connection';
+import { runMigrations } from './migrations';
+import { migrations } from './schema';
+
+/**
+ * Initialises the database: opens the connection and applies any pending
+ * migrations. Safe to call multiple times — migrations are idempotent.
+ */
+export function initDatabase(): void {
+  const db = getDatabase();
+  runMigrations(db, migrations);
+}

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runMigrations } from './migrations';
+import type { Migration } from './migrations';
+
+function freshDb(): Database {
+  return new Database(':memory:');
+}
+
+const migrationA: Migration = {
+  version: 1,
+  name: 'create_foo',
+  sql: 'CREATE TABLE foo (id INTEGER PRIMARY KEY, val TEXT NOT NULL);',
+};
+
+const migrationB: Migration = {
+  version: 2,
+  name: 'create_bar',
+  sql: 'CREATE TABLE bar (id INTEGER PRIMARY KEY);',
+};
+
+describe('runMigrations', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  test('applies a single migration and returns 1', () => {
+    const count = runMigrations(db, [migrationA]);
+    expect(count).toBe(1);
+  });
+
+  test('creates the migrated table', () => {
+    runMigrations(db, [migrationA]);
+    // Inserting into the created table should succeed
+    db.exec("INSERT INTO foo (val) VALUES ('x');");
+    const row = db.query<{ val: string }, []>('SELECT val FROM foo;').get();
+    expect(row?.val).toBe('x');
+  });
+
+  test('records applied migration in schema_migrations', () => {
+    runMigrations(db, [migrationA]);
+    const row = db.query<{ version: number; name: string }, []>(
+      'SELECT version, name FROM schema_migrations;'
+    ).get();
+    expect(row?.version).toBe(1);
+    expect(row?.name).toBe('create_foo');
+  });
+
+  test('applied_at is a positive integer', () => {
+    const before = Date.now();
+    runMigrations(db, [migrationA]);
+    const row = db.query<{ applied_at: number }, []>(
+      'SELECT applied_at FROM schema_migrations;'
+    ).get();
+    expect(row?.applied_at).toBeGreaterThanOrEqual(before);
+  });
+
+  test('applies multiple migrations in version order', () => {
+    // Pass them out of order to verify sorting
+    const count = runMigrations(db, [migrationB, migrationA]);
+    expect(count).toBe(2);
+    const rows = db.query<{ version: number }, []>(
+      'SELECT version FROM schema_migrations ORDER BY version;'
+    ).all();
+    expect(rows.map((r) => r.version)).toEqual([1, 2]);
+  });
+
+  test('returns 0 and skips already-applied migrations', () => {
+    runMigrations(db, [migrationA]);
+    const count = runMigrations(db, [migrationA]);
+    expect(count).toBe(0);
+  });
+
+  test('only applies pending migrations on re-run', () => {
+    runMigrations(db, [migrationA]);
+    const count = runMigrations(db, [migrationA, migrationB]);
+    expect(count).toBe(1);
+  });
+
+  test('returns 0 for empty migrations list', () => {
+    const count = runMigrations(db, []);
+    expect(count).toBe(0);
+  });
+
+  test('rolls back a failing migration and leaves db in last good state', () => {
+    const bad: Migration = {
+      version: 2,
+      name: 'bad_migration',
+      sql: 'THIS IS NOT VALID SQL !!!',
+    };
+    runMigrations(db, [migrationA]);
+    expect(() => runMigrations(db, [migrationA, bad])).toThrow();
+
+    // schema_migrations should still only have version 1
+    const rows = db.query<{ version: number }, []>(
+      'SELECT version FROM schema_migrations;'
+    ).all();
+    expect(rows.map((r) => r.version)).toEqual([1]);
+  });
+});

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,0 +1,83 @@
+/**
+ * ISEE v2 — Database Migrations
+ *
+ * A simple sequential migration system.
+ * Each migration is an object with a version number and a SQL string.
+ * Migrations are applied once and never re-run; applied versions are
+ * tracked in the `schema_migrations` table.
+ */
+
+import type { Database } from 'bun:sqlite';
+
+export interface Migration {
+  /** Monotonically increasing version number (1-based) */
+  version: number;
+  /** Human-readable name, used for logging */
+  name: string;
+  /** SQL to execute (may contain multiple statements separated by semicolons) */
+  sql: string;
+}
+
+/**
+ * Ensures the migrations tracking table exists.
+ */
+function ensureMigrationsTable(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version   INTEGER PRIMARY KEY,
+      name      TEXT    NOT NULL,
+      applied_at INTEGER NOT NULL
+    );
+  `);
+}
+
+/**
+ * Returns the highest migration version already applied, or 0 if none.
+ */
+function getAppliedVersion(db: Database): number {
+  ensureMigrationsTable(db);
+  const row = db.query<{ version: number }, []>(
+    'SELECT COALESCE(MAX(version), 0) AS version FROM schema_migrations;'
+  ).get();
+  return row?.version ?? 0;
+}
+
+/**
+ * Runs all pending migrations in order.
+ * Each migration is executed inside its own transaction so a failure
+ * leaves the database in the last good state.
+ *
+ * @param db - Open database connection
+ * @param migrations - Full ordered list of migrations (sorted by version ascending)
+ * @returns Number of migrations applied in this call
+ */
+export function runMigrations(db: Database, migrations: Migration[]): number {
+  ensureMigrationsTable(db);
+
+  const currentVersion = getAppliedVersion(db);
+  const pending = migrations
+    .filter((m) => m.version > currentVersion)
+    .sort((a, b) => a.version - b.version);
+
+  if (pending.length === 0) {
+    console.log('[db] No pending migrations.');
+    return 0;
+  }
+
+  let applied = 0;
+  for (const migration of pending) {
+    console.log(`[db] Applying migration ${migration.version}: ${migration.name}`);
+
+    db.transaction(() => {
+      db.exec(migration.sql);
+      db.prepare(
+        'INSERT INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?);'
+      ).run(migration.version, migration.name, Date.now());
+    })();
+
+    applied++;
+    console.log(`[db] Migration ${migration.version} applied.`);
+  }
+
+  return applied;
+}

--- a/src/db/schema.test.ts
+++ b/src/db/schema.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { migrations } from './schema';
+import { runMigrations } from './migrations';
+
+function freshDb(): Database {
+  return new Database(':memory:');
+}
+
+describe('schema migrations', () => {
+  test('migrations array is non-empty', () => {
+    expect(migrations.length).toBeGreaterThan(0);
+  });
+
+  test('version numbers are unique and start at 1', () => {
+    const versions = migrations.map((m) => m.version);
+    const unique = new Set(versions);
+    expect(unique.size).toBe(versions.length);
+    expect(Math.min(...versions)).toBe(1);
+  });
+
+  test('migrations are sorted by version ascending', () => {
+    for (let i = 1; i < migrations.length; i++) {
+      expect(migrations[i].version).toBeGreaterThan(migrations[i - 1].version);
+    }
+  });
+
+  test('every migration has a non-empty name and sql', () => {
+    for (const m of migrations) {
+      expect(m.name.trim().length).toBeGreaterThan(0);
+      expect(m.sql.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test('applies all migrations without error', () => {
+    const db = freshDb();
+    expect(() => runMigrations(db, migrations)).not.toThrow();
+  });
+});
+
+describe('initial_schema (v1)', () => {
+  let db: Database;
+
+  // Apply the schema once for all tests in this block
+  db = freshDb();
+  runMigrations(db, migrations);
+
+  test('runs table exists with expected columns', () => {
+    const info = db.query<{ name: string }, []>('PRAGMA table_info(runs);').all();
+    const cols = info.map((r) => r.name);
+    expect(cols).toContain('id');
+    expect(cols).toContain('query');
+    expect(cols).toContain('status');
+    expect(cols).toContain('created_at');
+    expect(cols).toContain('completed_at');
+    expect(cols).toContain('duration_ms');
+    expect(cols).toContain('error_message');
+    expect(cols).toContain('stats_json');
+  });
+
+  test('briefings table exists with expected columns', () => {
+    const info = db.query<{ name: string }, []>('PRAGMA table_info(briefings);').all();
+    const cols = info.map((r) => r.name);
+    expect(cols).toContain('id');
+    expect(cols).toContain('run_id');
+    expect(cols).toContain('query');
+    expect(cols).toContain('timestamp');
+    expect(cols).toContain('ideas_json');
+    expect(cols).toContain('debate_json');
+    expect(cols).toContain('domains_json');
+    expect(cols).toContain('markdown');
+    expect(cols).toContain('created_at');
+  });
+
+  test('inserting a run row succeeds', () => {
+    db.exec(`
+      INSERT INTO runs (id, query, status, created_at)
+      VALUES ('run-1', 'test query', 'running', ${Date.now()});
+    `);
+    const row = db.query<{ id: string }, [string]>('SELECT id FROM runs WHERE id = ?;').get('run-1');
+    expect(row?.id).toBe('run-1');
+  });
+
+  test('inserting a briefing with valid run_id succeeds', () => {
+    db.exec(`
+      INSERT INTO briefings (id, run_id, query, timestamp, ideas_json, debate_json, domains_json, markdown, created_at)
+      VALUES ('brief-1', 'run-1', 'test query', '2026-01-01T00:00:00Z', '[]', '[]', '[]', '# hi', ${Date.now()});
+    `);
+    const row = db.query<{ id: string }, [string]>('SELECT id FROM briefings WHERE id = ?;').get('brief-1');
+    expect(row?.id).toBe('brief-1');
+  });
+
+  test('briefings declares a foreign key referencing runs', () => {
+    const fkList = db.query<{ table: string; to: string }, []>(
+      'PRAGMA foreign_key_list(briefings);'
+    ).all();
+    expect(fkList.length).toBeGreaterThan(0);
+    expect(fkList[0].table).toBe('runs');
+    expect(fkList[0].to).toBe('id');
+  });
+
+  test('runs status defaults to running', () => {
+    db.exec(`
+      INSERT INTO runs (id, query, created_at)
+      VALUES ('run-default', 'q', ${Date.now()});
+    `);
+    const row = db.query<{ status: string }, [string]>('SELECT status FROM runs WHERE id = ?;').get('run-default');
+    expect(row?.status).toBe('running');
+  });
+
+  test('migrations are idempotent when applied twice', () => {
+    const db2 = freshDb();
+    runMigrations(db2, migrations);
+    const count = runMigrations(db2, migrations);
+    expect(count).toBe(0);
+  });
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,51 @@
+/**
+ * ISEE v2 — Database Schema
+ *
+ * Defines all migrations that make up the database schema.
+ * Add new migrations at the end of the array; never edit existing ones.
+ *
+ * Tables:
+ *   runs       — one row per pipeline execution (lifecycle tracking)
+ *   briefings  — the output of a completed run (ideas, debate, markdown)
+ */
+
+import type { Migration } from './migrations';
+
+export const migrations: Migration[] = [
+  {
+    version: 1,
+    name: 'initial_schema',
+    sql: `
+      -- Tracks the lifecycle of each pipeline execution.
+      CREATE TABLE IF NOT EXISTS runs (
+        id           TEXT    PRIMARY KEY,          -- UUID assigned at run start
+        query        TEXT    NOT NULL,             -- The user's query (refined or original)
+        status       TEXT    NOT NULL DEFAULT 'running',  -- 'running' | 'completed' | 'failed'
+        created_at   INTEGER NOT NULL,             -- Unix epoch ms
+        completed_at INTEGER,                      -- NULL until run finishes
+        duration_ms  INTEGER,                      -- Total pipeline duration
+        error_message TEXT,                        -- Set on failure
+        stats_json   TEXT                          -- JSON-serialised RunStats (nullable)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_runs_status     ON runs (status);
+      CREATE INDEX IF NOT EXISTS idx_runs_created_at ON runs (created_at DESC);
+
+      -- Stores the output produced by a successfully completed run.
+      CREATE TABLE IF NOT EXISTS briefings (
+        id           TEXT    PRIMARY KEY,          -- UUID (same as run_id for 1-to-1 mapping)
+        run_id       TEXT    NOT NULL REFERENCES runs (id) ON DELETE CASCADE,
+        query        TEXT    NOT NULL,
+        timestamp    TEXT    NOT NULL,             -- ISO-8601 string from Briefing.timestamp
+        ideas_json   TEXT    NOT NULL,             -- JSON-serialised ExtractedIdea[]
+        debate_json  TEXT    NOT NULL,             -- JSON-serialised DebateEntry[]
+        domains_json TEXT    NOT NULL,             -- JSON-serialised Domain[]
+        markdown     TEXT    NOT NULL,             -- Full rendered markdown briefing
+        created_at   INTEGER NOT NULL              -- Unix epoch ms
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_briefings_run_id    ON briefings (run_id);
+      CREATE INDEX IF NOT EXISTS idx_briefings_created_at ON briefings (created_at DESC);
+    `,
+  },
+];


### PR DESCRIPTION
## Summary

Implements Component 1.1 (Database Setup) from the Production Layer specification:

- **`src/db/connection.ts`**: Singleton SQLite database connection via `bun:sqlite`
  - WAL mode enabled for better read concurrency
  - Foreign key constraints enforced
  - Path configurable via `DB_PATH` env var (default `./data/isee.db`)

- **`src/db/migrations.ts`**: Sequential migration system
  - Tracks applied versions in `schema_migrations` table
  - Each migration runs in its own transaction (rollback on failure)
  - Idempotent - safe to call multiple times

- **`src/db/schema.ts`**: Initial schema (version 1)
  - `runs` table: pipeline execution lifecycle tracking
  - `briefings` table: output storage with FK to runs
  - Indexes on common query patterns

- **`src/db/index.ts`**: Public API with `initDatabase()` entry point

## Test Plan

- [x] 28 unit tests covering all modules (run `bun test src/db/`)
- [x] TypeScript type checking passes
- [x] Connection singleton behavior verified
- [x] Migration idempotency verified
- [x] Schema structure validated

## Integration

To wire into server.ts (follow-up PR):
\`\`\`typescript
import { initDatabase } from './db';
// at startup, before Bun.serve(...)
initDatabase();
\`\`\`

Part of Production Layer Phase 1 - Week 1: Foundation