### PR TITLE
feat: add run persistence module with LLM call tracking

### DIFF
--- a/src/db/connection.test.ts
+++ b/src/db/connection.test.ts
@@ -25,10 +25,12 @@ describe('getDatabase', () => {
     expect(db1).toBe(db2);
   });
 
-  test('has WAL journal mode enabled', () => {
+  test('does not use WAL journal mode for :memory: databases', () => {
+    // SQLite does not support WAL for in-memory databases; it falls back to
+    // 'memory' mode. WAL is only enabled for file-backed databases.
     const db = getDatabase();
     const row = db.query<{ journal_mode: string }, []>('PRAGMA journal_mode;').get();
-    expect(row?.journal_mode).toBe('wal');
+    expect(row?.journal_mode).toBe('memory');
   });
 
   test('has foreign key enforcement enabled', () => {

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -10,25 +10,35 @@ import { Database } from 'bun:sqlite';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-const DB_PATH = process.env.DB_PATH || './data/isee.db';
-
 let _db: Database | null = null;
 
 /**
  * Returns the singleton SQLite database connection.
  * Creates the database file and parent directory if they do not exist.
  * WAL mode is enabled for better read concurrency during long pipeline runs.
+ *
+ * The database path is read from the `DB_PATH` environment variable at
+ * connection creation time (not module load time) so that tests can override
+ * it with `process.env.DB_PATH = ':memory:'` before the first call.
  */
 export function getDatabase(): Database {
   if (_db) return _db;
 
-  // Ensure the parent directory exists
-  mkdirSync(dirname(DB_PATH), { recursive: true });
+  const dbPath = process.env.DB_PATH || './data/isee.db';
 
-  _db = new Database(DB_PATH, { create: true });
+  // Ensure the parent directory exists (no-op for ':memory:')
+  if (dbPath !== ':memory:') {
+    mkdirSync(dirname(dbPath), { recursive: true });
+  }
 
-  // Enable WAL mode for better concurrent read performance
-  _db.exec('PRAGMA journal_mode = WAL;');
+  _db = new Database(dbPath, { create: true });
+
+  // WAL mode improves concurrent read performance for file-backed databases.
+  // SQLite silently ignores it for :memory: databases (returns 'memory' instead
+  // of 'wal'), so we only set it for file-backed databases.
+  if (dbPath !== ':memory:') {
+    _db.exec('PRAGMA journal_mode = WAL;');
+  }
 
   // Enforce foreign key constraints
   _db.exec('PRAGMA foreign_keys = ON;');

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -9,6 +9,8 @@ export { getDatabase, closeDatabase } from './connection';
 export { runMigrations } from './migrations';
 export type { Migration } from './migrations';
 export { migrations } from './schema';
+export { createRun, getRunById, updateRun, getRuns } from './runs';
+export { logLlmCall, getLlmCallsByRunId, getCallStats } from './llm-calls';
 
 import { getDatabase } from './connection';
 import { runMigrations } from './migrations';

--- a/src/db/llm-calls.test.ts
+++ b/src/db/llm-calls.test.ts
@@ -1,0 +1,164 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { getDatabase, closeDatabase } from './connection';
+import { runMigrations } from './migrations';
+import { migrations } from './schema';
+import { createRun } from './runs';
+import { logLlmCall, getLlmCallsByRunId, getCallStats } from './llm-calls';
+import type { LlmCallRecord } from '../types';
+
+function setup() {
+  process.env.DB_PATH = ':memory:';
+  closeDatabase();
+  const db = getDatabase();
+  runMigrations(db, migrations);
+  // Seed a parent run so FK constraint is satisfied
+  createRun({ id: 'run-001', query: 'Test query', startedAt: new Date().toISOString() });
+}
+
+function teardown() {
+  closeDatabase();
+  delete process.env.DB_PATH;
+}
+
+const baseCall = (): LlmCallRecord => ({
+  runId: 'run-001',
+  stage: 'synthesis',
+  provider: 'openrouter',
+  model: 'anthropic/claude-sonnet-4',
+  inputTokens: 500,
+  outputTokens: 300,
+  latencyMs: 1200,
+  success: true,
+  costUsd: 0.006,
+  framework: 'analytical',
+  domain: 'Behavioral Economics',
+  timestamp: new Date().toISOString(),
+});
+
+describe('logLlmCall', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('inserts a call without throwing', () => {
+    expect(() => logLlmCall(baseCall())).not.toThrow();
+  });
+
+  test('inserts a failed call with error fields', () => {
+    const call: LlmCallRecord = {
+      ...baseCall(),
+      success: false,
+      errorType: 'rate_limit_exceeded',
+      errorMessage: 'Too many requests',
+      costUsd: undefined,
+    };
+    expect(() => logLlmCall(call)).not.toThrow();
+  });
+
+  test('inserts a call with minimal required fields', () => {
+    const minimal: LlmCallRecord = {
+      runId: 'run-001',
+      stage: 'clustering',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-20250514',
+      success: true,
+      timestamp: new Date().toISOString(),
+    };
+    expect(() => logLlmCall(minimal)).not.toThrow();
+  });
+});
+
+describe('getLlmCallsByRunId', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns empty array when no calls exist for run', () => {
+    expect(getLlmCallsByRunId('run-001')).toEqual([]);
+  });
+
+  test('returns only calls for the specified run', () => {
+    // Second run for isolation check
+    createRun({ id: 'run-002', query: 'Another query', startedAt: new Date().toISOString() });
+
+    logLlmCall(baseCall()); // run-001
+    logLlmCall({ ...baseCall(), runId: 'run-002', model: 'openai/gpt-4o' });
+
+    const calls = getLlmCallsByRunId('run-001');
+    expect(calls.length).toBe(1);
+    expect(calls[0].runId).toBe('run-001');
+    expect(calls[0].model).toBe('anthropic/claude-sonnet-4');
+  });
+
+  test('maps all fields correctly for a successful call', () => {
+    logLlmCall(baseCall());
+    const [call] = getLlmCallsByRunId('run-001');
+    expect(call.stage).toBe('synthesis');
+    expect(call.provider).toBe('openrouter');
+    expect(call.model).toBe('anthropic/claude-sonnet-4');
+    expect(call.inputTokens).toBe(500);
+    expect(call.outputTokens).toBe(300);
+    expect(call.latencyMs).toBe(1200);
+    expect(call.success).toBe(true);
+    expect(call.costUsd).toBeCloseTo(0.006);
+    expect(call.framework).toBe('analytical');
+    expect(call.domain).toBe('Behavioral Economics');
+  });
+
+  test('maps success = false correctly', () => {
+    logLlmCall({ ...baseCall(), success: false, errorType: 'timeout' });
+    const [call] = getLlmCallsByRunId('run-001');
+    expect(call.success).toBe(false);
+    expect(call.errorType).toBe('timeout');
+  });
+
+  test('returns calls ordered by timestamp ascending', () => {
+    const t0 = new Date(1000).toISOString();
+    const t1 = new Date(2000).toISOString();
+    logLlmCall({ ...baseCall(), timestamp: t1 });
+    logLlmCall({ ...baseCall(), timestamp: t0 });
+    const calls = getLlmCallsByRunId('run-001');
+    expect(calls[0].timestamp).toBe(t0);
+    expect(calls[1].timestamp).toBe(t1);
+  });
+});
+
+describe('getCallStats', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns zeros when run has no calls', () => {
+    const stats = getCallStats('run-001');
+    expect(stats.total).toBe(0);
+    expect(stats.successful).toBe(0);
+    expect(stats.totalCost).toBe(0);
+  });
+
+  test('counts total and successful calls', () => {
+    logLlmCall(baseCall()); // success
+    logLlmCall({ ...baseCall(), success: false, costUsd: 0 }); // failure
+    const stats = getCallStats('run-001');
+    expect(stats.total).toBe(2);
+    expect(stats.successful).toBe(1);
+  });
+
+  test('sums cost_usd correctly', () => {
+    logLlmCall({ ...baseCall(), costUsd: 0.01 });
+    logLlmCall({ ...baseCall(), costUsd: 0.02 });
+    const stats = getCallStats('run-001');
+    expect(stats.totalCost).toBeCloseTo(0.03);
+  });
+
+  test('treats null cost_usd as 0 in sum', () => {
+    logLlmCall({ ...baseCall(), costUsd: undefined });
+    const stats = getCallStats('run-001');
+    expect(stats.totalCost).toBe(0);
+  });
+
+  test('only counts calls belonging to the specified run', () => {
+    createRun({ id: 'run-002', query: 'Another query', startedAt: new Date().toISOString() });
+    logLlmCall({ ...baseCall(), costUsd: 0.05 });
+    logLlmCall({ ...baseCall(), runId: 'run-002', costUsd: 0.99 });
+    const stats = getCallStats('run-001');
+    expect(stats.total).toBe(1);
+    expect(stats.totalCost).toBeCloseTo(0.05);
+  });
+});

--- a/src/db/llm-calls.ts
+++ b/src/db/llm-calls.ts
@@ -1,0 +1,142 @@
+/**
+ * ISEE v2 — LLM Call Logging
+ *
+ * Operations for the `llm_calls` table.
+ * Every LLM API request during a pipeline run is recorded here for cost
+ * tracking, latency analysis, and failure attribution.
+ */
+
+import { getDatabase } from './connection';
+import type { LlmCallRecord } from '../types';
+
+// ---------------------------------------------------------------------------
+// Internal row shape (snake_case as stored in SQLite)
+// ---------------------------------------------------------------------------
+
+interface LlmCallRow {
+  id: number;
+  run_id: string;
+  stage: string;
+  provider: string;
+  model: string;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  latency_ms: number | null;
+  success: number; // SQLite stores booleans as integers
+  error_type: string | null;
+  error_message: string | null;
+  cost_usd: number | null;
+  framework: string | null;
+  domain: string | null;
+  cluster_id: number | null;
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+function rowToRecord(row: LlmCallRow): LlmCallRecord {
+  return {
+    runId: row.run_id,
+    stage: row.stage,
+    provider: row.provider as LlmCallRecord['provider'],
+    model: row.model,
+    ...(row.input_tokens != null && { inputTokens: row.input_tokens }),
+    ...(row.output_tokens != null && { outputTokens: row.output_tokens }),
+    ...(row.latency_ms != null && { latencyMs: row.latency_ms }),
+    success: row.success === 1,
+    ...(row.error_type != null && { errorType: row.error_type }),
+    ...(row.error_message != null && { errorMessage: row.error_message }),
+    ...(row.cost_usd != null && { costUsd: row.cost_usd }),
+    ...(row.framework != null && { framework: row.framework }),
+    ...(row.domain != null && { domain: row.domain }),
+    ...(row.cluster_id != null && { clusterId: row.cluster_id }),
+    timestamp: row.timestamp,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Inserts a single LLM call record into the database.
+ * The call's `id` is auto-assigned by SQLite.
+ */
+export function logLlmCall(call: LlmCallRecord): void {
+  const db = getDatabase();
+
+  db.prepare(`
+    INSERT INTO llm_calls (
+      run_id, stage, provider, model,
+      input_tokens, output_tokens, latency_ms, success,
+      error_type, error_message, cost_usd,
+      framework, domain, cluster_id, timestamp
+    ) VALUES (
+      ?, ?, ?, ?,
+      ?, ?, ?, ?,
+      ?, ?, ?,
+      ?, ?, ?, ?
+    )
+  `).run(
+    call.runId,
+    call.stage,
+    call.provider,
+    call.model,
+    call.inputTokens ?? null,
+    call.outputTokens ?? null,
+    call.latencyMs ?? null,
+    call.success ? 1 : 0,
+    call.errorType ?? null,
+    call.errorMessage ?? null,
+    call.costUsd ?? null,
+    call.framework ?? null,
+    call.domain ?? null,
+    call.clusterId ?? null,
+    call.timestamp,
+  );
+}
+
+/**
+ * Returns all LLM call records for the given run, ordered by timestamp ascending.
+ */
+export function getLlmCallsByRunId(runId: string): LlmCallRecord[] {
+  const db = getDatabase();
+  const rows = db.query<LlmCallRow, [string]>(
+    'SELECT * FROM llm_calls WHERE run_id = ? ORDER BY timestamp ASC'
+  ).all(runId);
+  return rows.map(rowToRecord);
+}
+
+/**
+ * Aggregates call statistics for a run.
+ *
+ * @returns An object containing the total call count, number of successful
+ *          calls, and cumulative cost in USD.
+ */
+export function getCallStats(runId: string): {
+  total: number;
+  successful: number;
+  totalCost: number;
+} {
+  const db = getDatabase();
+
+  const row = db.query<
+    { total: number; successful: number; total_cost: number | null },
+    [string]
+  >(
+    `SELECT
+       COUNT(*)                          AS total,
+       SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS successful,
+       SUM(cost_usd)                     AS total_cost
+     FROM llm_calls
+     WHERE run_id = ?`
+  ).get(runId);
+
+  return {
+    total: row?.total ?? 0,
+    successful: row?.successful ?? 0,
+    totalCost: row?.total_cost ?? 0,
+  };
+}

--- a/src/db/runs.test.ts
+++ b/src/db/runs.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { getDatabase, closeDatabase } from './connection';
+import { runMigrations } from './migrations';
+import { migrations } from './schema';
+import { createRun, getRunById, updateRun, getRuns } from './runs';
+import type { RunRecord } from '../types';
+
+function setup() {
+  process.env.DB_PATH = ':memory:';
+  closeDatabase();
+  const db = getDatabase();
+  runMigrations(db, migrations);
+}
+
+function teardown() {
+  closeDatabase();
+  delete process.env.DB_PATH;
+}
+
+const baseRun = (): Parameters<typeof createRun>[0] => ({
+  id: 'run-001',
+  query: 'How can we improve remote collaboration?',
+  startedAt: new Date().toISOString(),
+});
+
+describe('createRun', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('inserts and returns a RunRecord with defaults', () => {
+    const record = createRun(baseRun());
+    expect(record.id).toBe('run-001');
+    expect(record.status).toBe('running');
+    expect(record.query).toBe('How can we improve remote collaboration?');
+    expect(record.completedAt).toBeUndefined();
+    expect(record.errorMessage).toBeUndefined();
+  });
+
+  test('persists optional fields when provided', () => {
+    const run = {
+      ...baseRun(),
+      id: 'run-002',
+      status: 'completed' as RunRecord['status'],
+      refinedQuery: 'Refined: How can we improve remote collaboration?',
+      durationMs: 42000,
+      synthesisCallCount: 60,
+      successfulCalls: 58,
+      clusterCount: 6,
+      totalCostUsd: 0.12,
+      openrouterCostUsd: 0.09,
+      anthropicCostUsd: 0.03,
+    };
+    const record = createRun(run);
+    expect(record.status).toBe('completed');
+    expect(record.refinedQuery).toBe('Refined: How can we improve remote collaboration?');
+    expect(record.durationMs).toBe(42000);
+    expect(record.synthesisCallCount).toBe(60);
+    expect(record.successfulCalls).toBe(58);
+    expect(record.clusterCount).toBe(6);
+    expect(record.totalCostUsd).toBeCloseTo(0.12);
+    expect(record.openrouterCostUsd).toBeCloseTo(0.09);
+    expect(record.anthropicCostUsd).toBeCloseTo(0.03);
+  });
+});
+
+describe('getRunById', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns null for unknown id', () => {
+    expect(getRunById('does-not-exist')).toBeNull();
+  });
+
+  test('returns the run for a known id', () => {
+    createRun(baseRun());
+    const record = getRunById('run-001');
+    expect(record).not.toBeNull();
+    expect(record!.id).toBe('run-001');
+  });
+});
+
+describe('updateRun', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('updates specified fields without touching others', () => {
+    createRun(baseRun());
+    const now = new Date().toISOString();
+    updateRun('run-001', { status: 'completed', completedAt: now, durationMs: 5000 });
+    const record = getRunById('run-001');
+    expect(record!.status).toBe('completed');
+    expect(record!.completedAt).toBe(now);
+    expect(record!.durationMs).toBe(5000);
+    // untouched field
+    expect(record!.query).toBe('How can we improve remote collaboration?');
+  });
+
+  test('is a no-op when updates object is empty', () => {
+    createRun(baseRun());
+    expect(() => updateRun('run-001', {})).not.toThrow();
+  });
+
+  test('can mark a run as failed with an error message', () => {
+    createRun(baseRun());
+    updateRun('run-001', { status: 'failed', errorMessage: 'Clustering agent timed out' });
+    const record = getRunById('run-001');
+    expect(record!.status).toBe('failed');
+    expect(record!.errorMessage).toBe('Clustering agent timed out');
+  });
+});
+
+describe('getRuns', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns empty array when no runs exist', () => {
+    expect(getRuns()).toEqual([]);
+  });
+
+  test('returns all runs when no filter is applied', () => {
+    createRun({ ...baseRun(), id: 'run-a' });
+    createRun({ ...baseRun(), id: 'run-b', startedAt: new Date(Date.now() + 1).toISOString() });
+    const records = getRuns();
+    expect(records.length).toBe(2);
+  });
+
+  test('filters by status', () => {
+    createRun({ ...baseRun(), id: 'run-running' });
+    createRun({ ...baseRun(), id: 'run-done', status: 'completed' });
+    const running = getRuns({ status: 'running' });
+    expect(running.length).toBe(1);
+    expect(running[0].id).toBe('run-running');
+  });
+
+  test('respects limit', () => {
+    for (let i = 0; i < 5; i++) {
+      createRun({ ...baseRun(), id: `run-${i}`, startedAt: new Date(Date.now() + i).toISOString() });
+    }
+    const limited = getRuns({ limit: 3 });
+    expect(limited.length).toBe(3);
+  });
+
+  test('returns results in descending started_at order', () => {
+    const t0 = new Date(1000).toISOString();
+    const t1 = new Date(2000).toISOString();
+    createRun({ ...baseRun(), id: 'run-old', startedAt: t0 });
+    createRun({ ...baseRun(), id: 'run-new', startedAt: t1 });
+    const records = getRuns();
+    expect(records[0].id).toBe('run-new');
+    expect(records[1].id).toBe('run-old');
+  });
+});

--- a/src/db/runs.ts
+++ b/src/db/runs.ts
@@ -1,0 +1,185 @@
+/**
+ * ISEE v2 — Run Persistence
+ *
+ * CRUD operations for the `runs` table.
+ * Each row tracks the lifecycle of one pipeline execution.
+ */
+
+import { getDatabase } from './connection';
+import type { RunRecord } from '../types';
+
+// ---------------------------------------------------------------------------
+// Internal row shape (snake_case as stored in SQLite)
+// ---------------------------------------------------------------------------
+
+interface RunRow {
+  id: string;
+  api_key_id: string | null;
+  query: string;
+  refined_query: string | null;
+  status: string;
+  created_at: number;      // Unix epoch ms — from v1 schema (NOT NULL)
+  started_at: string | null; // ISO-8601 — added in migration v2
+  completed_at: string | null;
+  duration_ms: number | null;
+  error_message: string | null;
+  synthesis_call_count: number | null;
+  successful_calls: number | null;
+  cluster_count: number | null;
+  total_cost_usd: number | null;
+  openrouter_cost_usd: number | null;
+  anthropic_cost_usd: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+function rowToRecord(row: RunRow): RunRecord {
+  // started_at was added in migration v2; fall back to created_at for old rows
+  const startedAt = row.started_at ?? new Date(row.created_at).toISOString();
+
+  return {
+    id: row.id,
+    ...(row.api_key_id != null && { apiKeyId: row.api_key_id }),
+    query: row.query,
+    ...(row.refined_query != null && { refinedQuery: row.refined_query }),
+    status: row.status as RunRecord['status'],
+    startedAt,
+    ...(row.completed_at != null && { completedAt: row.completed_at }),
+    ...(row.duration_ms != null && { durationMs: row.duration_ms }),
+    ...(row.error_message != null && { errorMessage: row.error_message }),
+    ...(row.synthesis_call_count != null && { synthesisCallCount: row.synthesis_call_count }),
+    ...(row.successful_calls != null && { successfulCalls: row.successful_calls }),
+    ...(row.cluster_count != null && { clusterCount: row.cluster_count }),
+    ...(row.total_cost_usd != null && { totalCostUsd: row.total_cost_usd }),
+    ...(row.openrouter_cost_usd != null && { openrouterCostUsd: row.openrouter_cost_usd }),
+    ...(row.anthropic_cost_usd != null && { anthropicCostUsd: row.anthropic_cost_usd }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Inserts a new run record. At minimum `id`, `query`, and `startedAt` must be
+ * provided; all other fields are optional and default to their column defaults.
+ *
+ * @returns The newly created RunRecord as stored in the database.
+ */
+export function createRun(run: Partial<RunRecord> & { id: string; query: string; startedAt: string }): RunRecord {
+  const db = getDatabase();
+
+  const now = run.startedAt ?? new Date().toISOString();
+
+  db.prepare(`
+    INSERT INTO runs (
+      id, api_key_id, query, refined_query, status,
+      created_at, started_at,
+      completed_at, duration_ms, error_message,
+      synthesis_call_count, successful_calls, cluster_count,
+      total_cost_usd, openrouter_cost_usd, anthropic_cost_usd
+    ) VALUES (
+      ?, ?, ?, ?, ?,
+      ?, ?,
+      ?, ?, ?,
+      ?, ?, ?,
+      ?, ?, ?
+    )
+  `).run(
+    run.id,
+    run.apiKeyId ?? null,
+    run.query,
+    run.refinedQuery ?? null,
+    run.status ?? 'running',
+    Date.now(),
+    now,
+    run.completedAt ?? null,
+    run.durationMs ?? null,
+    run.errorMessage ?? null,
+    run.synthesisCallCount ?? null,
+    run.successfulCalls ?? null,
+    run.clusterCount ?? null,
+    run.totalCostUsd ?? null,
+    run.openrouterCostUsd ?? null,
+    run.anthropicCostUsd ?? null,
+  );
+
+  // Return the persisted record (always present since INSERT just succeeded)
+  return getRunById(run.id) as RunRecord;
+}
+
+/**
+ * Retrieves a run by its ID.
+ *
+ * @returns The RunRecord, or `null` if not found.
+ */
+export function getRunById(id: string): RunRecord | null {
+  const db = getDatabase();
+  const row = db.query<RunRow, [string]>('SELECT * FROM runs WHERE id = ?').get(id);
+  return row ? rowToRecord(row) : null;
+}
+
+/**
+ * Applies a partial update to a run.
+ * Only the fields present in `updates` are modified.
+ */
+export function updateRun(id: string, updates: Partial<RunRecord>): void {
+  const db = getDatabase();
+
+  const fieldMap: Record<string, string> = {
+    apiKeyId: 'api_key_id',
+    query: 'query',
+    refinedQuery: 'refined_query',
+    status: 'status',
+    startedAt: 'started_at', // v2 column
+    completedAt: 'completed_at',
+    durationMs: 'duration_ms',
+    errorMessage: 'error_message',
+    synthesisCallCount: 'synthesis_call_count',
+    successfulCalls: 'successful_calls',
+    clusterCount: 'cluster_count',
+    totalCostUsd: 'total_cost_usd',
+    openrouterCostUsd: 'openrouter_cost_usd',
+    anthropicCostUsd: 'anthropic_cost_usd',
+  };
+
+  const setClauses: string[] = [];
+  const values: unknown[] = [];
+
+  for (const [key, value] of Object.entries(updates)) {
+    const column = fieldMap[key];
+    if (column) {
+      setClauses.push(`${column} = ?`);
+      values.push(value ?? null);
+    }
+  }
+
+  if (setClauses.length === 0) return;
+
+  values.push(id);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db.prepare(`UPDATE runs SET ${setClauses.join(', ')} WHERE id = ?`).run(...(values as any[]));
+}
+
+/**
+ * Returns a list of runs, optionally filtered by status and capped at a limit.
+ * Results are ordered by `started_at` descending (most recent first).
+ */
+export function getRuns(options: { status?: string; limit?: number } = {}): RunRecord[] {
+  const db = getDatabase();
+  const { status, limit = 100 } = options;
+
+  if (status) {
+    const rows = db.query<RunRow, [string, number]>(
+      'SELECT * FROM runs WHERE status = ? ORDER BY COALESCE(started_at, datetime(created_at / 1000, \'unixepoch\')) DESC LIMIT ?'
+    ).all(status, limit);
+    return rows.map(rowToRecord);
+  }
+
+  const rows = db.query<RunRow, [number]>(
+    'SELECT * FROM runs ORDER BY COALESCE(started_at, datetime(created_at / 1000, \'unixepoch\')) DESC LIMIT ?'
+  ).all(limit);
+  return rows.map(rowToRecord);
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,9 +4,10 @@
  * Defines all migrations that make up the database schema.
  * Add new migrations at the end of the array; never edit existing ones.
  *
- * Tables:
- *   runs       — one row per pipeline execution (lifecycle tracking)
- *   briefings  — the output of a completed run (ideas, debate, markdown)
+ * Migrations:
+ *   v1 — initial_schema: runs + briefings tables
+ *   v2 — extend_runs: add cost/stats/auth columns and started_at to runs
+ *   v3 — add_llm_calls: per-call telemetry table
  */
 
 import type { Migration } from './migrations';
@@ -46,6 +47,53 @@ export const migrations: Migration[] = [
 
       CREATE INDEX IF NOT EXISTS idx_briefings_run_id    ON briefings (run_id);
       CREATE INDEX IF NOT EXISTS idx_briefings_created_at ON briefings (created_at DESC);
+    `,
+  },
+  {
+    version: 2,
+    name: 'extend_runs',
+    sql: `
+      -- Add production-layer columns to the runs table.
+      -- SQLite only supports ADD COLUMN, so these are appended one by one.
+      ALTER TABLE runs ADD COLUMN api_key_id        TEXT;
+      ALTER TABLE runs ADD COLUMN refined_query     TEXT;
+      ALTER TABLE runs ADD COLUMN started_at        TEXT;
+      ALTER TABLE runs ADD COLUMN synthesis_call_count INTEGER;
+      ALTER TABLE runs ADD COLUMN successful_calls  INTEGER;
+      ALTER TABLE runs ADD COLUMN cluster_count     INTEGER;
+      ALTER TABLE runs ADD COLUMN total_cost_usd    REAL;
+      ALTER TABLE runs ADD COLUMN openrouter_cost_usd REAL;
+      ALTER TABLE runs ADD COLUMN anthropic_cost_usd  REAL;
+
+      -- Back-fill started_at from created_at for any existing rows.
+      UPDATE runs SET started_at = datetime(created_at / 1000, 'unixepoch') WHERE started_at IS NULL;
+    `,
+  },
+  {
+    version: 3,
+    name: 'add_llm_calls',
+    sql: `
+      -- Per-call telemetry for every LLM request within a pipeline run.
+      CREATE TABLE IF NOT EXISTS llm_calls (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id        TEXT    NOT NULL REFERENCES runs (id) ON DELETE CASCADE,
+        stage         TEXT    NOT NULL,             -- pipeline stage that made the call
+        provider      TEXT    NOT NULL,             -- 'openrouter' | 'anthropic'
+        model         TEXT    NOT NULL,             -- model identifier
+        input_tokens  INTEGER,                      -- prompt token count
+        output_tokens INTEGER,                      -- completion token count
+        latency_ms    INTEGER,                      -- wall-clock ms for the call
+        success       INTEGER NOT NULL DEFAULT 1,   -- 1 = success, 0 = failure (SQLite bool)
+        error_type    TEXT,                         -- e.g. 'rate_limit_exceeded'
+        error_message TEXT,                         -- full error message if failed
+        cost_usd      REAL,                         -- computed cost in USD
+        framework     TEXT,                         -- cognitive framework (synthesis stage)
+        domain        TEXT,                         -- knowledge domain (synthesis stage)
+        cluster_id    INTEGER,                      -- cluster id (tournament stage)
+        timestamp     TEXT    NOT NULL              -- ISO-8601 call timestamp
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_llm_calls_run_id ON llm_calls (run_id);
     `,
   },
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,6 +331,56 @@ export interface SynthesisModel {
 }
 
 // ============================================================================
+// Production Layer Types
+// ============================================================================
+
+/**
+ * Persisted record for a single pipeline execution.
+ */
+export interface RunRecord {
+  id: string;
+  apiKeyId?: string;
+  query: string;
+  refinedQuery?: string;
+  status: 'running' | 'completed' | 'failed';
+  startedAt: string;
+  completedAt?: string;
+  durationMs?: number;
+  errorMessage?: string;
+
+  // Stats
+  synthesisCallCount?: number;
+  successfulCalls?: number;
+  clusterCount?: number;
+
+  // Cost
+  totalCostUsd?: number;
+  openrouterCostUsd?: number;
+  anthropicCostUsd?: number;
+}
+
+/**
+ * Telemetry record for a single LLM API call within a run.
+ */
+export interface LlmCallRecord {
+  runId: string;
+  stage: string;
+  provider: 'openrouter' | 'anthropic';
+  model: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  latencyMs?: number;
+  success: boolean;
+  errorType?: string;
+  errorMessage?: string;
+  costUsd?: number;
+  framework?: string;
+  domain?: string;
+  clusterId?: number;
+  timestamp: string;
+}
+
+// ============================================================================
 // API Response Types
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Implements Component 1.2 (Run Persistence) from the Production Layer specification:

- **`src/types.ts`**: Added `RunRecord` and `LlmCallRecord` interfaces for type-safe persistence

- **`src/db/schema.ts`**: Added migrations v2 and v3
  - v2: Extends `runs` table with additional columns for stats tracking
  - v3: Creates `llm_calls` table for detailed LLM call logging

- **`src/db/runs.ts`**: CRUD operations for runs
  - `createRun()`: Initialize a new pipeline run
  - `getRunById()`: Retrieve a specific run
  - `updateRun()`: Update run status/stats on completion/failure
  - `getRuns()`: Query runs with filtering and pagination

- **`src/db/llm-calls.ts`**: LLM call logging operations
  - `logLlmCall()`: Record individual LLM calls with metrics
  - `getLlmCallsByRunId()`: Retrieve all calls for a run
  - `getCallStats()`: Aggregated statistics (total, successful, cost)

- **`src/db/index.ts`**: Updated exports for all new functions and types

- **`src/db/connection.ts`**: Fixed lazy `DB_PATH` evaluation for proper test isolation

## Test Plan

- [x] 53 unit tests passing across 5 test files
- [x] 12 tests for runs CRUD operations
- [x] 13 tests for LLM call logging operations
- [x] TypeScript type checking passes
- [x] In-memory database isolation in tests

## Integration

To use in pipeline.ts (follow-up PR):
\`\`\`typescript
import { createRun, updateRun, logLlmCall } from './db';

// At pipeline start
const run = createRun({ id: crypto.randomUUID(), query });

// After each LLM call
logLlmCall({ runId: run.id, stage: 'synthesis', ... });

// On completion
updateRun(run.id, { status: 'completed', completedAt: Date.now() });
\`\`\`

Part of Production Layer Phase 1 - Week 1: Foundation