### PR TITLE
fix: run only src/ unit tests in quality job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: bun test src/
 
       - name: Build check
-        run: bun build src/server.ts --outdir=dist
+        run: bun build src/server.ts --outdir=dist --target=bun
 
   integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Golden tests require API keys and should only run in integration job.