### PR TITLE
fix: aggregate LLM costs to run record for dashboard display

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -10,7 +10,7 @@ export { runMigrations } from './migrations';
 export type { Migration } from './migrations';
 export { migrations } from './schema';
 export { createRun, getRunById, updateRun, getRuns } from './runs';
-export { logLlmCall, getLlmCallsByRunId, getCallStats } from './llm-calls';
+export { logLlmCall, getLlmCallsByRunId, getCallStats, getCostsByProvider } from './llm-calls';
 export { createApiKey, validateApiKey, getApiKeyById, revokeApiKey, listApiKeys, seedAdminKeyIfNeeded } from './api-keys';
 
 import { getDatabase } from './connection';

--- a/src/db/llm-calls.ts
+++ b/src/db/llm-calls.ts
@@ -140,3 +140,39 @@ export function getCallStats(runId: string): {
     totalCost: row?.total_cost ?? 0,
   };
 }
+
+/**
+ * Aggregates costs for a run broken down by provider.
+ *
+ * @returns Total cost and per-provider costs for openrouter and anthropic.
+ */
+export function getCostsByProvider(runId: string): {
+  totalCostUsd: number;
+  openrouterCostUsd: number;
+  anthropicCostUsd: number;
+} {
+  const db = getDatabase();
+
+  const rows = db.query<
+    { provider: string; provider_cost: number | null },
+    [string]
+  >(
+    `SELECT provider, SUM(cost_usd) AS provider_cost
+     FROM llm_calls
+     WHERE run_id = ?
+     GROUP BY provider`
+  ).all(runId);
+
+  let totalCostUsd = 0;
+  let openrouterCostUsd = 0;
+  let anthropicCostUsd = 0;
+
+  for (const row of rows) {
+    const cost = row.provider_cost ?? 0;
+    totalCostUsd += cost;
+    if (row.provider === 'openrouter') openrouterCostUsd = cost;
+    else if (row.provider === 'anthropic') anthropicCostUsd = cost;
+  }
+
+  return { totalCostUsd, openrouterCostUsd, anthropicCostUsd };
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -21,7 +21,7 @@ import { createRunLogger } from './utils/logger';
 import { withSpan } from './observability/spans';
 import { getTracer } from './observability/tracing';
 import { withTimeout, TIMEOUTS } from './resilience/timeout';
-import { createRun, updateRun, initDatabase } from './db';
+import { createRun, updateRun, initDatabase, getCostsByProvider } from './db';
 
 export interface PipelineResult {
   briefing: Briefing;
@@ -320,7 +320,8 @@ export async function runPipeline(
       // Render markdown
       const markdown = renderBriefingMarkdown(translatedBriefing);
 
-      // Update run record with final stats
+      // Aggregate costs from llm_calls and update run record with final stats
+      const costs = getCostsByProvider(runId);
       updateRun(runId, {
         status: 'completed',
         completedAt: new Date().toISOString(),
@@ -328,6 +329,9 @@ export async function runPipeline(
         synthesisCallCount: briefing.stats.synthesisCallCount,
         successfulCalls: briefing.stats.successfulCalls,
         clusterCount: briefing.stats.clusterCount,
+        totalCostUsd: costs.totalCostUsd,
+        openrouterCostUsd: costs.openrouterCostUsd,
+        anthropicCostUsd: costs.anthropicCostUsd,
       });
 
       return { briefing, translatedBriefing, markdown };

--- a/test/db-cost-aggregation.test.ts
+++ b/test/db-cost-aggregation.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for cost aggregation via getCostsByProvider and the updateRun cost fields.
+ *
+ * Uses an in-memory SQLite database to avoid touching the real data file.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { initDatabase, closeDatabase, logLlmCall, getCostsByProvider, createRun, updateRun, getRunById } from '../src/db';
+
+function setup() {
+  process.env.DB_PATH = ':memory:';
+  closeDatabase(); // reset singleton so new :memory: db is created
+  initDatabase();
+}
+
+function teardown() {
+  closeDatabase();
+  delete process.env.DB_PATH;
+}
+
+describe('getCostsByProvider', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns zeros when no calls exist for run', () => {
+    const result = getCostsByProvider('nonexistent-run');
+    expect(result.totalCostUsd).toBe(0);
+    expect(result.openrouterCostUsd).toBe(0);
+    expect(result.anthropicCostUsd).toBe(0);
+  });
+
+  test('aggregates openrouter and anthropic costs separately', () => {
+    const runId = 'test-run-1';
+    createRun({ id: runId, query: 'test query', startedAt: new Date().toISOString() });
+
+    logLlmCall({ runId, stage: 'synthesis', provider: 'openrouter', model: 'gpt-4', success: true, costUsd: 0.01, timestamp: new Date().toISOString() });
+    logLlmCall({ runId, stage: 'synthesis', provider: 'openrouter', model: 'gpt-4', success: true, costUsd: 0.02, timestamp: new Date().toISOString() });
+    logLlmCall({ runId, stage: 'clustering', provider: 'anthropic', model: 'claude-3', success: true, costUsd: 0.05, timestamp: new Date().toISOString() });
+
+    const result = getCostsByProvider(runId);
+    expect(result.openrouterCostUsd).toBeCloseTo(0.03);
+    expect(result.anthropicCostUsd).toBeCloseTo(0.05);
+    expect(result.totalCostUsd).toBeCloseTo(0.08);
+  });
+
+  test('handles null cost_usd entries gracefully', () => {
+    const runId = 'test-run-null-cost';
+    createRun({ id: runId, query: 'test query', startedAt: new Date().toISOString() });
+
+    // cost_usd omitted — treated as null in DB
+    logLlmCall({ runId, stage: 'synthesis', provider: 'openrouter', model: 'gpt-4', success: false, timestamp: new Date().toISOString() });
+    logLlmCall({ runId, stage: 'synthesis', provider: 'openrouter', model: 'gpt-4', success: true, costUsd: 0.03, timestamp: new Date().toISOString() });
+
+    const result = getCostsByProvider(runId);
+    expect(result.openrouterCostUsd).toBeCloseTo(0.03);
+    expect(result.totalCostUsd).toBeCloseTo(0.03);
+  });
+
+  test('does not include costs from other runs', () => {
+    const runA = 'run-a';
+    const runB = 'run-b';
+    createRun({ id: runA, query: 'query A', startedAt: new Date().toISOString() });
+    createRun({ id: runB, query: 'query B', startedAt: new Date().toISOString() });
+
+    logLlmCall({ runId: runA, stage: 'synthesis', provider: 'openrouter', model: 'gpt-4', success: true, costUsd: 0.10, timestamp: new Date().toISOString() });
+    logLlmCall({ runId: runB, stage: 'synthesis', provider: 'openrouter', model: 'gpt-4', success: true, costUsd: 0.99, timestamp: new Date().toISOString() });
+
+    const result = getCostsByProvider(runA);
+    expect(result.totalCostUsd).toBeCloseTo(0.10);
+  });
+});
+
+describe('updateRun cost fields', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('stores aggregated costs on the run record', () => {
+    const runId = 'cost-update-run';
+    createRun({ id: runId, query: 'test', startedAt: new Date().toISOString() });
+
+    logLlmCall({ runId, stage: 'synthesis', provider: 'openrouter', model: 'gpt-4', success: true, costUsd: 0.04, timestamp: new Date().toISOString() });
+    logLlmCall({ runId, stage: 'clustering', provider: 'anthropic', model: 'claude-3', success: true, costUsd: 0.06, timestamp: new Date().toISOString() });
+
+    const costs = getCostsByProvider(runId);
+    updateRun(runId, {
+      status: 'completed',
+      completedAt: new Date().toISOString(),
+      totalCostUsd: costs.totalCostUsd,
+      openrouterCostUsd: costs.openrouterCostUsd,
+      anthropicCostUsd: costs.anthropicCostUsd,
+    });
+
+    const run = getRunById(runId);
+    expect(run).not.toBeNull();
+    expect(run!.totalCostUsd).toBeCloseTo(0.10);
+    expect(run!.openrouterCostUsd).toBeCloseTo(0.04);
+    expect(run!.anthropicCostUsd).toBeCloseTo(0.06);
+    expect(run!.status).toBe('completed');
+  });
+
+  test('total_cost_usd remains null when no llm_calls exist', () => {
+    const runId = 'no-calls-run';
+    createRun({ id: runId, query: 'test', startedAt: new Date().toISOString() });
+
+    const costs = getCostsByProvider(runId);
+    // Both provider costs are 0 since no rows exist; totalCostUsd = 0 (not null)
+    updateRun(runId, {
+      status: 'completed',
+      totalCostUsd: costs.totalCostUsd,
+      openrouterCostUsd: costs.openrouterCostUsd,
+      anthropicCostUsd: costs.anthropicCostUsd,
+    });
+
+    const run = getRunById(runId);
+    expect(run!.totalCostUsd).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #26 - Dashboard summary Total Cost shows $0.00 despite logged costs.

**Root Cause**: The summary card reads from `runs.total_cost_usd`, but the `updateRun()` call at pipeline completion never populated that field. Costs were logged per-call to `llm_calls` but not aggregated back to the `runs` table.

**Fix**: Query `SUM(cost_usd) FROM llm_calls WHERE run_id = ? GROUP BY provider` at pipeline completion and write the totals to `runs.total_cost_usd`, `runs.openrouter_cost_usd`, and `runs.anthropic_cost_usd`.

## Changes

- **`src/db/llm-calls.ts`**: Added `getCostsByProvider(runId)` function that aggregates costs by provider
- **`src/db/index.ts`**: Exported `getCostsByProvider`
- **`src/pipeline.ts`**: Calls `getCostsByProvider(runId)` after pipeline completion and passes costs to `updateRun()`
- **`test/db-cost-aggregation.test.ts`**: New test file with 6 tests covering the cost aggregation logic

## Test plan

- [x] TypeScript: No errors
- [x] New cost aggregation tests: 6/6 pass
- [x] All DB unit tests: 73/73 pass
- [ ] Manual verification: Run a pipeline and confirm dashboard Total Cost shows correct value