### PR TITLE
fix: correct P95 latency calculation for model statistics

### DIFF
--- a/src/dashboard/handlers.test.ts
+++ b/src/dashboard/handlers.test.ts
@@ -7,6 +7,7 @@ import { getDatabase, closeDatabase } from '../db/connection';
 import { runMigrations } from '../db/migrations';
 import { migrations } from '../db/schema';
 import { createRun, updateRun } from '../db/runs';
+import { logLlmCall } from '../db/llm-calls';
 import { clearCache } from './cache';
 import { resetAllBreakers } from '../resilience/circuit-breaker';
 import {
@@ -162,6 +163,55 @@ describe('getModelStats', () => {
     const s1 = await getModelStats();
     const s2 = await getModelStats();
     expect(s1).toEqual(s2);
+  });
+
+  test('calculates p95LatencyMs correctly for small sample (< 20 calls)', async () => {
+    const runId = 'p95-small';
+    createRun({ id: runId, query: 'test', startedAt: new Date().toISOString(), status: 'completed' });
+    // Insert 4 calls with latencies 100, 200, 300, 400
+    const latencies = [100, 200, 300, 400];
+    for (const latencyMs of latencies) {
+      logLlmCall({
+        runId,
+        stage: 'synthesis',
+        provider: 'openrouter',
+        model: 'test-model',
+        latencyMs,
+        success: true,
+        timestamp: new Date().toISOString(),
+      });
+    }
+    clearCache();
+    const stats = await getModelStats();
+    const modelStat = stats.find(s => s.model === 'test-model');
+    expect(modelStat).toBeDefined();
+    // p95 of [100,200,300,400]: idx = ceil(4 * 0.95) - 1 = ceil(3.8) - 1 = 4 - 1 = 3 → value = 400
+    expect(modelStat!.p95LatencyMs).toBe(400);
+    expect(modelStat!.p95LatencyMs).not.toBe(0);
+  });
+
+  test('calculates p95LatencyMs correctly for larger sample', async () => {
+    const runId = 'p95-large';
+    createRun({ id: runId, query: 'test', startedAt: new Date().toISOString(), status: 'completed' });
+    // Insert 20 calls with latencies 100, 200, ..., 2000
+    for (let i = 1; i <= 20; i++) {
+      logLlmCall({
+        runId,
+        stage: 'synthesis',
+        provider: 'openrouter',
+        model: 'large-model',
+        latencyMs: i * 100,
+        success: true,
+        timestamp: new Date().toISOString(),
+      });
+    }
+    clearCache();
+    const stats = await getModelStats();
+    const modelStat = stats.find(s => s.model === 'large-model');
+    expect(modelStat).toBeDefined();
+    // p95 of [100..2000]: idx = ceil(20 * 0.95) - 1 = ceil(19) - 1 = 19 - 1 = 18 → value = 1900
+    expect(modelStat!.p95LatencyMs).toBe(1900);
+    expect(modelStat!.p95LatencyMs).not.toBe(0);
   });
 });
 

--- a/src/db/metrics.ts
+++ b/src/db/metrics.ts
@@ -316,25 +316,29 @@ export function getModelStatistics(): ModelStats[] {
      ORDER BY provider, model`,
   ).all();
 
-  // Get p95 approximation per provider+model using ordered subquery
-  const p95Rows = db.query<{ provider: string; model: string; p95: number }, []>(
-    `SELECT provider, model, latency_ms AS p95
-     FROM (
-       SELECT
-         provider,
-         model,
-         latency_ms,
-         NTILE(20) OVER (PARTITION BY provider, model ORDER BY latency_ms) AS tile
-       FROM llm_calls
-       WHERE latency_ms IS NOT NULL AND success = 1
-     )
-     WHERE tile = 19
-     GROUP BY provider, model`,
+  // Get p95 per provider+model using application-level percentile calculation.
+  // Fetching sorted latency values per model and computing percentile in TS
+  // is simpler and always correct regardless of sample size.
+  const latencyRows = db.query<{ provider: string; model: string; latency_ms: number }, []>(
+    `SELECT provider, model, latency_ms
+     FROM llm_calls
+     WHERE latency_ms IS NOT NULL AND success = 1
+     ORDER BY provider, model, latency_ms`,
   ).all();
 
+  const latencyGroups = new Map<string, number[]>();
+  for (const r of latencyRows) {
+    const key = `${r.provider}:${r.model}`;
+    const arr = latencyGroups.get(key) ?? [];
+    arr.push(r.latency_ms);
+    latencyGroups.set(key, arr);
+  }
+
   const p95Map = new Map<string, number>();
-  for (const r of p95Rows) {
-    p95Map.set(`${r.provider}:${r.model}`, r.p95);
+  for (const [key, values] of latencyGroups) {
+    // values is already sorted ASC by the SQL ORDER BY
+    const idx = Math.ceil(values.length * 0.95) - 1;
+    p95Map.set(key, values[Math.max(0, idx)]);
   }
 
   return rows.map(r => ({


### PR DESCRIPTION
## Summary

Fix P95 latency calculation for model statistics. `NTILE(20)` never assigns tile 19 for models with fewer than 20 successful calls, causing `p95LatencyMs` to always return 0.

## Changes

- `src/db/metrics.ts` - Replace broken `NTILE(20)/tile=19` SQL window function with application-level percentile calculation that fetches sorted latency values per model and computes the 95th percentile index (correct for any sample size)
- `src/dashboard/handlers.test.ts` - Add two tests: small sample (<20 calls) and larger sample (20 calls) to cover both code paths

## Validation

- [x] Type check passes
- [x] Tests pass (including new P95 latency tests)

## Testing Notes

Two new tests added:
1. Small sample (<20 calls) — previously returned 0, now returns correct P95
2. Larger sample (20 calls) — validates correct percentile index selection

---

Closes #27
